### PR TITLE
CodeClimate re-integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,21 @@ jobs:
       - name: Install dependencies
         run: npm install
       - run: npm run lint
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+      - run: cp .env.sample .env
+      - name: Install dependencies
+        run: npm install
+      - name: Run Tests
+        run: npm run coverage
   coverage:
     name: Test and publish test coverage
     # The OS on which the job will run


### PR DESCRIPTION
I ended up merging some trivial test updates so now that we're wired up again I'm ready to reinclude the test step. 

@tinomen and @ashtilawat23 I don't know that we need both a test step and coverage step. But I'll differ to y'all on that idea. 

This PR simply adds the steps in the build to publish back the coverage report from jest to Code Climate. 

<img width="1494" alt="image" src="https://user-images.githubusercontent.com/8798259/159783116-424fc6c4-579e-495a-91a4-1ca6933a5033.png">

If you install the CodeClimate browser extension you should see those badges 👆 at the top of the repo page.