### PR TITLE
Fixed faker dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -521,6 +521,12 @@
         }
       }
     },
+    "@faker-js/faker": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-6.1.1.tgz",
+      "integrity": "sha512-8yq1LJVGn4GY06riLddIU1LbJm15yjt46hjfkpWNpH/mqdciPOBVzicKOJxzQNrGgVHVBxcdm7sgwjI/Y19MYw==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
@@ -2823,12 +2829,6 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
-    },
-    "faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg==",
-      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "swagger-ui-express": "^4.3.0"
   },
   "devDependencies": {
+    "@faker-js/faker": "^6.1.1",
     "cross-env": "^7.0.3",
     "debug": "~4.3.3",
     "eslint": "^8.10.0",
@@ -78,7 +79,6 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^6.0.0",
-    "faker": "^6.6.6",
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "lint-staged": "^12.3.4",


### PR DESCRIPTION
### Why was this work done? 
- Faker is no longer supported. 

### What work was done? 
- Corrected faker with  the new dependency. 
- @faker-js/faker was added. 